### PR TITLE
Bump version, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,33 @@
+#### 0.0.6 (2026-02-12)
+
+#### New features
+
+- Add `date_add_months` json-logic operator [3f16cc2d8aa28578c75f0bcd2661f1f3eae12ab1](https://github.com/remoteoss/remote-json-schema-form-kit/commit/3f16cc2d8aa28578c75f0bcd2661f1f3eae12ab1)
+
 #### 0.0.5 (2026-01-21)
 
 #### New features
 
-- Export ModifyConfig, ValidationResult and FormErrors types [44a70c3cdb9f6ca4d2f6bcffe99d345d70bab2eb](https://github.com/remoteoss/remote-json-schema-form-ki/commit/44a70c3cdb9f6ca4d2f6bcffe99d345d70bab2eb)
-
+- Export `ModifyConfig`, `ValidationResult` and `FormErrors` types [44a70c3cdb9f6ca4d2f6bcffe99d345d70bab2eb](https://github.com/remoteoss/remote-json-schema-form-kit/commit/44a70c3cdb9f6ca4d2f6bcffe99d345d70bab2eb)
 
 #### 0.0.4 (2026-01-20)
 
 #### New features
 
-- bump json-schema-form package version to 1.2.9 [15d767a57589d82c8f2fb80df9324e0827ea6acf](https://github.com/remoteoss/remote-json-schema-form-ki/commit/5683e829f4c6acb7ab04b21d2fd49c89f5a18c2c)
+- bump `@remoteoss/json-schema-form` to 1.2.9 [15d767a57589d82c8f2fb80df9324e0827ea6acf](https://github.com/remoteoss/remote-json-schema-form-kit/commit/5683e829f4c6acb7ab04b21d2fd49c89f5a18c2c)
 
 
-#### 0.0.3 
+#### 0.0.3
 
 #### New features
 
-- bump json-schema-form package version to 1.2.8 [b8ba9bf8b9ae8ad5d9d81ce1f8160d5cba3e1f5c](https://github.com/remoteoss/remote-json-schema-form-ki/commit/b8ba9bf8b9ae8ad5d9d81ce1f8160d5cba3e1f5c)
+- bump `@remoteoss/json-schema-form` to 1.2.8 [b8ba9bf8b9ae8ad5d9d81ce1f8160d5cba3e1f5c](https://github.com/remoteoss/remote-json-schema-form-kit/commit/b8ba9bf8b9ae8ad5d9d81ce1f8160d5cba3e1f5c)
 
 #### 0.0.2 (2025-11-21)
 
 #### New features
 
-- Add types definition ([5683e829f4c6acb7ab04b21d2fd49c89f5a18c2c](https://github.com/remoteoss/remote-json-schema-form-ki/commit/5683e829f4c6acb7ab04b21d2fd49c89f5a18c2c))
+- Add types definition ([5683e829f4c6acb7ab04b21d2fd49c89f5a18c2c](https://github.com/remoteoss/remote-json-schema-form-kit/commit/5683e829f4c6acb7ab04b21d2fd49c89f5a18c2c))
 
 #### 0.0.1 (2025-11-14)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-json-schema-form-kit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-json-schema-form-kit",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@remoteoss/json-schema-form": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remoteoss/remote-json-schema-form-kit",
   "type": "module",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "packageManager": "npm@10.9.1-r0",
   "description": "Remote's kit for json-schema-form",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release bookkeeping only (version and changelog updates) with no functional code changes in this diff.
> 
> **Overview**
> Bumps `@remoteoss/remote-json-schema-form-kit` version from `0.0.5` to `0.0.6` in `package.json` and `package-lock.json`.
> 
> Updates `CHANGELOG.md` for `0.0.6`, documenting the new `date_add_months` json-logic operator and cleaning up prior changelog entries/links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a73af31dcc6ca116ff54c5ee1c74266746724e1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->