### PR TITLE
Bump version to v0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.0.7 (2026-02-19)
+
+#### New features
+
+- Add `date_format` json-logic operator [5449a70cf09132b02ba63ff5cf872e2fb993de20](https://github.com/remoteoss/remote-json-schema-form-kit/commit/5449a70cf09132b02ba63ff5cf872e2fb993de20)
+
 #### 0.0.6 (2026-02-12)
 
 #### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@remoteoss/remote-json-schema-form-kit",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@remoteoss/remote-json-schema-form-kit",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
         "@remoteoss/json-schema-form": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@remoteoss/remote-json-schema-form-kit",
   "type": "module",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "packageManager": "npm@10.9.1-r0",
   "description": "Remote's kit for json-schema-form",
   "author": "Remote.com <engineering@remote.com> (https://remote.com/)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release/version metadata and documentation-only changes; no runtime code paths are modified in this PR.
> 
> **Overview**
> Updates the release metadata by bumping the package version from `0.0.6` to `0.0.7` in `package.json` and `package-lock.json`.
> 
> Adds a `0.0.7` entry to `CHANGELOG.md` noting the new `date_format` json-logic operator.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dcb47c57e92071e2ec73e39a6b4531d428cd89a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->